### PR TITLE
Handle missing RUNNER_WORKSPACE in lint utilities

### DIFF
--- a/tools/lint/utils.py
+++ b/tools/lint/utils.py
@@ -53,13 +53,22 @@ def emit_problem_matchers(log_path: str, matcher_filename: str, remove_owner: st
     """
     if os.path.isfile(log_path):
         runner_workspace = os.getenv("RUNNER_WORKSPACE")
-        matcher_path = os.path.join(
-            runner_workspace, "FreeCAD", ".github", "problemMatcher", matcher_filename
-        )
-        print(f"::add-matcher::{matcher_path}")
-        with open(log_path, "r", encoding="utf-8") as f:
-            sys.stdout.write(f.read())
-        print(f"::remove-matcher owner={remove_owner}::")
+        if runner_workspace:
+            matcher_path = os.path.join(
+                runner_workspace,
+                "FreeCAD",
+                ".github",
+                "problemMatcher",
+                matcher_filename,
+            )
+            print(f"::add-matcher::{matcher_path}")
+            with open(log_path, "r", encoding="utf-8") as f:
+                sys.stdout.write(f.read())
+            print(f"::remove-matcher owner={remove_owner}::")
+        else:
+            logging.warning("RUNNER_WORKSPACE is not set; skipping problem matcher emission")
+            with open(log_path, "r", encoding="utf-8") as f:
+                sys.stdout.write(f.read())
 
 
 def add_common_arguments(parser: argparse.ArgumentParser) -> argparse.ArgumentParser:


### PR DESCRIPTION
## Summary
- avoid TypeError when RUNNER_WORKSPACE missing in emit_problem_matchers

## Testing
- `pre-commit run --files tools/lint/utils.py`
- `pytest` *(fails: Interrupted: 32 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68ae89679e2c8332a52179ce10002a7f